### PR TITLE
Use ghc-head & head.hackage again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install-nix
-        uses: DeterminateSystems/nix-installer-action@v9
+        uses: DeterminateSystems/nix-installer-action@v10
 
       - name: build-frontend
         run: |

--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,8 @@
 packages: . hs2048
 
-index-state: 2024-04-09T09:10:13Z
+index-state: 2024-04-15T08:03:57Z
 
-if os(wasi)
+if arch(wasm32)
   -- https://github.com/haskellari/splitmix/pull/73
   source-repository-package
     type: git
@@ -23,23 +23,15 @@ if os(wasi)
 if impl(ghc >= 9.10)
   allow-newer:
     , base
+    , deepseq
     , ghc-prim
     , template-haskell
 
-  source-repository-package
-    type: git
-    location: https://github.com/haskell-hvr/text-short
-    tag: 9c4c133afc0b0d284e9c61477dcb9a20862f49f8
+  packages: https://ghc.gitlab.haskell.org/head.hackage/package/text-short-0.1.5.tar.gz
 
-  source-repository-package
-    type: git
-    location: https://github.com/amesgen/free
-    tag: b5528b004b1b3a62989647ec2ef9a312e33739d0
+  packages: https://ghc.gitlab.haskell.org/head.hackage/package/free-5.2.tar.gz
 
   package reflection
     flags: -template-haskell
 
-  source-repository-package
-    type: git
-    location: https://github.com/amesgen/lens
-    tag: 3be3dae69175d3e417da40afa148232da71deba7
+  packages: https://ghc.gitlab.haskell.org/head.hackage/package/lens-5.2.3.tar.gz

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     {
       devShells.default = pkgs.mkShell {
         packages = [
-          inputs.ghc-wasm-meta.packages.${system}.all_9_10
+          inputs.ghc-wasm-meta.packages.${system}.all_gmp
           pkgs.npm-check-updates
           pkgs.dart-sass
           pkgs.zlib

--- a/flake.nix
+++ b/flake.nix
@@ -9,9 +9,7 @@
       devShells.default = pkgs.mkShell {
         packages = [
           inputs.ghc-wasm-meta.packages.${system}.all_gmp
-          pkgs.npm-check-updates
           pkgs.dart-sass
-          pkgs.zlib
         ];
       };
     });

--- a/frontend/build.sh
+++ b/frontend/build.sh
@@ -14,8 +14,7 @@ mkdir dist
 cp ./*.html dist/
 
 wasm32-wasi-cabal build ghc-wasm-miso-examples
-wasm32-wasi-cabal list-bin ghc-wasm-miso-examples
-hs_wasm_path=$(wasm32-wasi-cabal list-bin ghc-wasm-miso-examples)
+hs_wasm_path=$(find .. -name "*.wasm")
 
 "$(wasm32-wasi-ghc --print-libdir)"/post-link.mjs \
      --input "$hs_wasm_path" --output ghc_wasm_jsffi.js


### PR DESCRIPTION
ghc-9.10 is still undergoing breaking changes in TH and it's less troublesome to stick to ghc-head & head.hackage than to make our forked repos keep up with upstream changes. Also it'll make testing ghc-wasm-miso-examples in CI of ghc-wasm-meta much easier.