### PR TITLE
Adjust build plan per head.hackage changes

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -32,12 +32,21 @@ package reflection
 if impl(ghc >= 9.10)
   allow-newer:
     , base
+    , bytestring
+    , containers
     , deepseq
+    , filepath
     , ghc-prim
     , template-haskell
+    , text
+    , time
+
+  constraints:
+    directory installed,
+    process installed,
+    time installed,
+    unix installed
 
   packages: https://ghc.gitlab.haskell.org/head.hackage/package/text-short-0.1.5.tar.gz
-
-  packages: https://ghc.gitlab.haskell.org/head.hackage/package/free-5.2.tar.gz
 
   packages: https://ghc.gitlab.haskell.org/head.hackage/package/lens-5.2.3.tar.gz

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 packages: . hs2048
 
-index-state: 2024-04-20T23:09:54Z
+index-state: 2024-04-22T21:06:15Z
 
 if arch(wasm32)
   -- https://github.com/haskellari/splitmix/pull/73

--- a/cabal.project
+++ b/cabal.project
@@ -20,6 +20,15 @@ if arch(wasm32)
     location: https://github.com/amesgen/jsaddle-wasm
     tag: be129c788f8ca1ea2e9cc1515397c1a46d02bb41
 
+package aeson
+  flags: -ordered-keymap
+
+package QuickCheck
+  flags: -templateHaskell
+
+package reflection
+  flags: -template-haskell
+
 if impl(ghc >= 9.10)
   allow-newer:
     , base
@@ -30,8 +39,5 @@ if impl(ghc >= 9.10)
   packages: https://ghc.gitlab.haskell.org/head.hackage/package/text-short-0.1.5.tar.gz
 
   packages: https://ghc.gitlab.haskell.org/head.hackage/package/free-5.2.tar.gz
-
-  package reflection
-    flags: -template-haskell
 
   packages: https://ghc.gitlab.haskell.org/head.hackage/package/lens-5.2.3.tar.gz

--- a/cabal.project
+++ b/cabal.project
@@ -18,7 +18,7 @@ if arch(wasm32)
   source-repository-package
     type: git
     location: https://github.com/amesgen/jsaddle-wasm
-    tag: 55fe9d52f2f4164042d180eca80d098abed67042
+    tag: be129c788f8ca1ea2e9cc1515397c1a46d02bb41
 
 if impl(ghc >= 9.10)
   allow-newer:

--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
       },
       "locked": {
         "host": "gitlab.haskell.org",
-        "lastModified": 1713652818,
-        "narHash": "sha256-xwrapP27yKJ1oy5ykPE3X+feF+MLGdSvPnjbdE1M00c=",
+        "lastModified": 1713766300,
+        "narHash": "sha256-gNodIIx7UIua3l2WwUrDCQDsbkIPSiQydr+i83CFh8E=",
         "owner": "ghc",
         "repo": "ghc-wasm-meta",
-        "rev": "e1123a732a70938b817caa7470aa4124913937e1",
+        "rev": "f9b95689c5bd1c565e270879734d1663ff7ed8b4",
         "type": "gitlab"
       },
       "original": {


### PR DESCRIPTION
- `head.hackage` removed `free-5.2` in https://gitlab.haskell.org/ghc/head.hackage/-/commit/06b499d32f96a5366dbf290e30c39428761cbed6, adjust build plan accordingly
- Add some more `allow-newer` to ensure no boot libs are rebuilt
- Add `-ordered-keymap` to `aeson`, it's always good to have