### PR TITLE
Make examples runnable with `jsaddle-warp`

### DIFF
--- a/app/App.hs
+++ b/app/App.hs
@@ -1,7 +1,14 @@
+{-# LANGUAGE CPP #-}
+
 module App (start) where
 
+#ifdef wasi_HOST_OS
 import GHC.Wasm.Prim
 import Language.Javascript.JSaddle (JSM)
+#else
+import Language.Javascript.JSaddle
+#endif
+
 import SimpleCounter qualified
 import Snake qualified
 import TodoMVC qualified
@@ -10,7 +17,7 @@ import XHR qualified
 
 start :: JSString -> JSM ()
 start e =
-  case fromJSString e of
+  case fromJSString e :: String of
     "simplecounter" -> SimpleCounter.start
     "snake" -> Snake.start
     "todomvc" -> TodoMVC.start

--- a/app/App.hs
+++ b/app/App.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 
-module App (start) where
+module App (start, App(..)) where
 
 #ifdef wasi_HOST_OS
 import GHC.Wasm.Prim
@@ -9,18 +9,50 @@ import Language.Javascript.JSaddle (JSM)
 import Language.Javascript.JSaddle
 #endif
 
+import Data.Text.Lazy (Text)
 import SimpleCounter qualified
 import Snake qualified
 import TodoMVC qualified
 import TwoZeroFourEight qualified
 import XHR qualified
 
-start :: JSString -> JSM ()
+data App = App
+  { name :: Text
+  , stylesheets :: [Text]
+  , app :: JSM ()
+  }
+
+start :: JSString -> App
 start e =
   case fromJSString e :: String of
-    "simplecounter" -> SimpleCounter.start
-    "snake" -> Snake.start
-    "todomvc" -> TodoMVC.start
-    "xhr" -> XHR.start
-    "2048" -> TwoZeroFourEight.start
-    _ -> fail "unknown example"
+    "simplecounter" ->
+      App
+        { name = "SimpleCounter"
+        , stylesheets = []
+        , app = SimpleCounter.start
+        }
+    "snake" ->
+      App
+        { name = "Snake"
+        , stylesheets = []
+        , app = Snake.start
+        }
+    "todomvc" ->
+      App
+        { name = "TodoMVC"
+        , stylesheets = ["todomvc/base.css", "todomvc/index.css"]
+        , app = TodoMVC.start
+        }
+    "xhr" ->
+      App
+        { name = "XHR"
+        , stylesheets = []
+        , app = XHR.start
+        }
+    "2048" ->
+      App
+        { name = "TwoZeroFourEight"
+        , stylesheets = ["2048/main.css"]
+        , app = TwoZeroFourEight.start
+        }
+    _ -> error "unknown example"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,34 +1,75 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 #ifdef wasi_HOST_OS
 
 module MyMain (main) where
 
-import App (start)
+import App
 import GHC.Wasm.Prim
 import Language.Javascript.JSaddle.Wasm qualified as JSaddle.Wasm
 
 foreign export javascript "hs_start" main :: JSString -> IO ()
 
 main :: JSString -> IO ()
-main e = JSaddle.Wasm.run $ start e
+main e = JSaddle.Wasm.run (start e).app
 
 #else
 
 module Main (main) where
 
-import App (start)
+import App
+import Data.Text.Lazy qualified as T
+import Data.Text.Lazy.Encoding (encodeUtf8)
 import Language.Javascript.JSaddle
 import Language.Javascript.JSaddle.Warp
-import Network.Wai.Handler.Warp
-import Network.WebSockets
+import Network.Wai.Application.Static
 import System.Environment
 
+{- TODO
+work out how to live-reload on changes to stylesheet
+maybe don't use `dist` version...
+maybe just a matter of passing right flag to GHCID?
+in theory I shouldn't even need to do that - just force a page refresh
+is that something we can hook in to?
+
+open jsaddle PR and use it here as a SRP
+
+punt:
+somehow DRY to match static HTML files
+-}
 main :: IO ()
-main = getArgs >>= \case
-    [arg] -> runSettings (setPort 8000 defaultSettings)
-        =<< jsaddleOr defaultConnectionOptions (start $ toJSString arg)
-            jsaddleApp
-    _ -> fail "bad args: specify an example, e.g. 2048"
+main =
+    getArgs >>= \case
+        -- Note that `debug` works with `cabal repl` but not `cabal run`.
+        -- The best workflow is to run `ghcid -c "cabal repl ghc-wasm-miso-examples" -W -T ':main primer'`.
+        [arg] ->
+            let app =
+                    start
+                        -- "2048"
+                        (toJSString arg)
+                -- we can't use multiline syntax alongside CPP...
+                -- "<meta charset='utf-8'>\n\
+                -- \<meta name='viewport' content='width=device-width, initial-scale=1'>\n\
+                -- \<title>2048 | Miso example via GHC WASM</title>\n\
+                -- \<link rel='stylesheet' href='2048/main.css'/>\n\
+                -- \"
+                header =
+                    encodeUtf8 $
+                        T.unlines $
+                            [ "<title>" <> app.name <> "</title>"
+                            ]
+                                <> map
+                                    (\s -> "<link rel='stylesheet' href='" <> s <> "'/>")
+                                    app.stylesheets
+             in
+                -- can't work out how to get non-`debug` version working
+                -- but I think I prefer this anyway
+                 debugOr
+                    (Just header)
+                    8000
+                    app.app
+                    (staticApp (defaultWebAppSettings "frontend/dist"))
+        _ -> fail "bad args: specify an example, e.g. 2048"
 
 #endif

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -42,7 +42,7 @@ main :: IO ()
 main =
     getArgs >>= \case
         -- Note that `debug` works with `cabal repl` but not `cabal run`.
-        -- The best workflow is to run `ghcid -c "cabal repl ghc-wasm-miso-examples" -W -T ':main primer'`.
+        -- The best workflow is to run `ghcid -c "cabal repl ghc-wasm-miso-examples" -W -T ':main simplecounter'`.
         [arg] ->
             let app =
                     start

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 packages: . hs2048
 
-index-state: 2024-10-26T13:27:42Z
+index-state: 2024-11-25T21:40:33Z
 
 if arch(wasm32)
   -- Required for TemplateHaskell. When using wasm32-wasi-cabal from

--- a/cabal.project
+++ b/cabal.project
@@ -18,5 +18,13 @@ if arch(wasm32)
     location: https://github.com/amesgen/splitmix
     tag: 5f5b766d97dc735ac228215d240a3bb90bc2ff75
 
+else
+  -- https://github.com/ghcjs/jsaddle/pull/149
+  source-repository-package
+    type: git
+    location: https://github.com/georgefst/jsaddle
+    tag: 8ebf96891fe9580fc16e1fe99b0ca503b9cf2ed8
+    subdir: jsaddle jsaddle-warp
+
 package aeson
   flags: -ordered-keymap

--- a/ghc-wasm-miso-examples.cabal
+++ b/ghc-wasm-miso-examples.cabal
@@ -8,10 +8,8 @@ executable ghc-wasm-miso-examples
       , aeson
       , base
       , containers
-      , ghc-experimental
       , hs2048
       , jsaddle
-      , jsaddle-wasm
       , miso
       , mtl
       , random
@@ -26,4 +24,8 @@ executable ghc-wasm-miso-examples
       Snake
       TodoMVC
       XHR
-    ghc-options: -no-hs-main -optl-mexec-model=reactor "-optl-Wl,--export=hs_start"
+    if arch(wasm32)
+      build-depends: ghc-experimental, jsaddle-wasm
+      ghc-options: -no-hs-main -optl-mexec-model=reactor "-optl-Wl,--export=hs_start"
+    else
+      build-depends: jsaddle-warp, warp, websockets

--- a/ghc-wasm-miso-examples.cabal
+++ b/ghc-wasm-miso-examples.cabal
@@ -11,6 +11,7 @@ executable ghc-wasm-miso-examples
       , hs2048
       , jsaddle
       , miso
+      , miso >= 1.8.5.0
       , mtl
       , random
       , text

--- a/ghc-wasm-miso-examples.cabal
+++ b/ghc-wasm-miso-examples.cabal
@@ -29,4 +29,4 @@ executable ghc-wasm-miso-examples
       build-depends: ghc-experimental, jsaddle-wasm
       ghc-options: -no-hs-main -optl-mexec-model=reactor "-optl-Wl,--export=hs_start"
     else
-      build-depends: jsaddle-warp, warp, websockets
+      build-depends: jsaddle-warp, wai-app-static, warp, websockets


### PR DESCRIPTION
Allows running examples locally without targeting WASM, e.g. with `cabal run ghc-wasm-miso-examples -- snake`. Note that it doesn't work on Firefox: https://github.com/ghcjs/jsaddle/issues/64.

Code is largely adapted from [Miso's own example](https://github.com/dmjio/miso/blob/master/sample-app-jsaddle/Main.hs). I don't know whether there's any particular reason this hadn't already been done in this repository. Maybe just that GHC's WASM backend is nowhere near as slow as GHCJS, so it's a bit less important? Anyway, I thought I may as well see whether you'd be interested in upstreaming this before going any further.

Note that a major reason for this is HLS support: https://github.com/haskell/haskell-language-server/discussions/4187.

There are still quite a few things that could be improved:

- [ ] The two CPP branches in `Main.hs` are completely separate, so perhaps we're better off using two separate modules and Cabal conditionals instead.
- [ ] The CPP in `App.hs` is a bit awkward, and potentially overly complicated, since `Data.JSString.Internal.Type.JSString` is not the same as `GHC.Internal.Wasm.Prim.Types.JSString`. This is also the reason for the extra annotations in this file and `XHR.hs`: monomorphising the former gives us some compatiblity. It's possible that `jsaddle` could be improved to abstract over this difference.
- [ ] After a non-WASM build, building for WASM with `./build.sh` requires a `cabal clean`. Presumably more could be done to keep build folders separate.
  - I'm not certain yet, but I think this issue has gone away since rebasing on `main` after https://github.com/tweag/ghc-wasm-miso-examples/pull/24.
- [ ] I've ditched the GHCI stuff (i.e. `debug`) from the Miso examples for now. This is simpler and easier to understand, since `jsaddle-warp` has a pretty bad and under-documented API, but it does limit some of the main benefits.
  - It works perfectly well with GHCI (EDIT: except that writing to stdout no longer works...), but when compiled the program immediately just exits.
  - I'm not sure what the purpose of Miso's `debugOr 8080 (f >> syncPoint) jsaddleApp` is. I've found that just using `debug 8000 f` works fine.
- [ ] CSS isn't picked up. We can host the CSS files using `wai-app-static`, replacing `jsaddleApp` with `(jsaddleAppWithJsOr (jsaddleJs False) $ staticApp $ defaultWebAppSettings "frontend")`, but I don't know how we can specify stylesheets like in our static HTML since we can't seem to get at the document's head.
- [ ] For some reason, `fail "unknown example"` isn't called when passing an invalid CLI argument.
- [ ] The XHR example is not yet implemented since it was not trivial to adapt.
- [ ] This needs to be run _outside_ of the `nix develop` shell. I'm not totally sure why, but Cabal otherwise fails in fairly inscrutable ways.