### PR TITLE
Use latest Miso and make examples runnable with `jsaddle-warp`

### DIFF
--- a/app/App.hs
+++ b/app/App.hs
@@ -1,19 +1,23 @@
+{-# LANGUAGE CPP #-}
 module App (start) where
 
-import GHC.Wasm.Prim
 import Language.Javascript.JSaddle (JSM)
 import SimpleCounter qualified
 import Snake qualified
 import TodoMVC qualified
 import TwoZeroFourEight qualified
+#ifdef wasi_HOST_OS
 import XHR qualified
+#endif
 
-start :: JSString -> JSM ()
+start :: String -> JSM ()
 start e =
-  case fromJSString e of
+  case e of
     "simplecounter" -> SimpleCounter.start
     "snake" -> Snake.start
     "todomvc" -> TodoMVC.start
+#ifdef wasi_HOST_OS
     "xhr" -> XHR.start
+#endif
     "2048" -> TwoZeroFourEight.start
     _ -> fail "unknown example"

--- a/app/SimpleCounter.hs
+++ b/app/SimpleCounter.hs
@@ -3,15 +3,16 @@
 module SimpleCounter (start) where
 
 import Control.Monad.State.Strict
+import Language.Javascript.JSaddle (JSM)
 import Miso
 import Miso.String (ms)
 
 start :: JSM ()
-start = startApp App {..}
+start = startComponent Component {..}
   where
-    initialAction = 0
+    initialAction = Just 0
     model = 0 :: Int
-    update n = fromTransition do
+    update n = do
       modify' (+ n)
     view n =
       div_
@@ -27,6 +28,7 @@ start = startApp App {..}
     subs = []
     mountPoint = Nothing
     logLevel = Off
+    styles = []
 
 -- https://github.com/dmjio/miso/issues/631
 -- but it seems to work fine!
@@ -36,4 +38,4 @@ onClickPreventDefault a =
     (defaultOptions {preventDefault = True})
     "click"
     emptyDecoder
-    (\() -> a)
+    (\() _ -> a)

--- a/app/Snake.hs
+++ b/app/Snake.hs
@@ -35,7 +35,7 @@ every n f sink = void . forkJSM . forever $ do
 start :: JSM ()
 start = startComponent Component {..}
   where
-    initialAction = Just NoOp
+    initialAction = Nothing
     mountPoint = Nothing
     model  = NotStarted
     update = updateModel
@@ -87,7 +87,6 @@ data Msg
   | ArrowPress !Arrows
   | KeyboardPress !(Set.Set Int)
   | Spawn !Double !Position
-  | NoOp
 
 -- | Initial Snake
 initSnake :: Snake

--- a/app/Snake.hs
+++ b/app/Snake.hs
@@ -152,18 +152,18 @@ viewModel Started{..} =
 updateModel :: Msg -> Model -> Effect Model Msg
 updateModel msg NotStarted =
   case msg of
-       KeyboardPress keys | Set.member 32 keys -> noEff $ Started initSnake Nothing 0
-       _                                       -> noEff NotStarted
+       KeyboardPress keys | Set.member 32 keys -> put $ Started initSnake Nothing 0
+       _                                       -> put NotStarted
 updateModel (ArrowPress arrs) model@Started{..} =
   let newDir = getNewDirection arrs (direction snake)
       newSnake = snake { direction = newDir } in
-  noEff $ model { snake = newSnake }
+  put $ model { snake = newSnake }
 updateModel (Spawn chance (randX, randY)) model@Started{}
   | chance <= 0.1 =
      let newCherry = spawnCherry randX randY in
-     noEff model { cherry = newCherry }
+     put model { cherry = newCherry }
   | otherwise =
-     noEff model
+     put model
 updateModel (Tick _) model@Started{..} =
   let newHead = getNewSegment (shead snake) (direction snake)
       ateCherry = maybe False (isOverlap newHead) cherry
@@ -177,12 +177,12 @@ updateModel (Tick _) model@Started{..} =
       newModel = model { snake = newSnake, cherry = newCherry, score = newScore }
       gameOver = isGameOver newHead newTail
       in
-  if | gameOver          -> noEff NotStarted
+  if | gameOver          -> put NotStarted
      | cherry == Nothing -> newModel <# do
                                         [chance, xPos, yPos] <- replicateM 3 $ randomRIO (0, 1)
                                         return $ Spawn chance (xPos, yPos)
-     | otherwise         -> noEff newModel
-updateModel _ model = noEff model
+     | otherwise         -> put newModel
+updateModel _ model = put model
 
 getNewDirection :: Arrows -> Direction -> Direction
 getNewDirection (Arrows arrX arrY) dir

--- a/app/TodoMVC.hs
+++ b/app/TodoMVC.hs
@@ -83,7 +83,7 @@ data Msg
    deriving Show
 
 start :: JSM ()
-start = startComponent Component { initialAction = Just NoOp, ..}
+start = startComponent Component { initialAction = Nothing, ..}
   where
     model      = emptyModel
     update     = updateModel
@@ -97,7 +97,7 @@ start = startComponent Component { initialAction = Just NoOp, ..}
 updateModel :: Msg -> Effect Model Msg
 updateModel NoOp = pure ()
 updateModel (CurrentTime n) =
-  io_ (liftIO (print n)) >> issue NoOp
+  io_ $ liftIO (print n)
 updateModel Add = modify $ \model@Model{..} ->
   model {
     uid = uid + 1
@@ -113,7 +113,6 @@ updateModel (EditingEntry id' isEditing) = do
     in
       model { entries = newEntries }
   io_ $ focus $ S.pack $ "todo-" ++ show id'
-  issue NoOp
 
 updateModel (UpdateEntry id' task) = modify $ \model@Model{..} ->
   let
@@ -138,7 +137,6 @@ updateModel (Check id' isCompleted) = do
     in
       model { entries = newEntries }
   io_ $ liftIO (putStrLn "clicked check")
-  issue NoOp
 
 updateModel (CheckAll isCompleted) = modify $ \model@Model{..} ->
     let

--- a/app/TodoMVC.hs
+++ b/app/TodoMVC.hs
@@ -95,16 +95,16 @@ start = startComponent Component { initialAction = Just NoOp, ..}
     styles     = []
 
 updateModel :: Msg -> Model -> Effect Model Msg
-updateModel NoOp m = noEff m
+updateModel NoOp m = put m
 updateModel (CurrentTime n) m =
   m <# do liftIO (print n) >> pure NoOp
 updateModel Add model@Model{..} =
-  noEff model {
+  put model {
     uid = uid + 1
   , field = mempty
   , entries = entries <> [ newEntry field uid | not $ S.null field ]
   }
-updateModel (UpdateField str) model = noEff model { field = str }
+updateModel (UpdateField str) model = put model { field = str }
 updateModel (EditingEntry id' isEditing) model@Model{..} =
   model { entries = newEntries } <# do
     focus $ S.pack $ "todo-" ++ show id'
@@ -114,17 +114,17 @@ updateModel (EditingEntry id' isEditing) model@Model{..} =
          \t -> t { editing = isEditing, focussed = isEditing }
 
 updateModel (UpdateEntry id' task) model@Model{..} =
-  noEff model { entries = newEntries }
+  put model { entries = newEntries }
     where
       newEntries =
         filterMap entries ((==id') . eid) $ \t ->
            t { description = task }
 
 updateModel (Delete id') model@Model{..} =
-  noEff model { entries = filter (\t -> eid t /= id') entries }
+  put model { entries = filter (\t -> eid t /= id') entries }
 
 updateModel DeleteComplete model@Model{..} =
-  noEff model { entries = filter (not . completed) entries }
+  put model { entries = filter (not . completed) entries }
 
 updateModel (Check id' isCompleted) model@Model{..} =
    model { entries = newEntries } <# eff
@@ -138,14 +138,14 @@ updateModel (Check id' isCompleted) model@Model{..} =
           t { completed = isCompleted }
 
 updateModel (CheckAll isCompleted) model@Model{..} =
-  noEff model { entries = newEntries }
+  put model { entries = newEntries }
     where
       newEntries =
         filterMap entries (const True) $
           \t -> t { completed = isCompleted }
 
 updateModel (ChangeVisibility v) model =
-  noEff model { visibility = v }
+  put model { visibility = v }
 
 filterMap :: [a] -> (a -> Bool) -> (a -> a) -> [a]
 filterMap xs predicate f = go' xs

--- a/app/XHR.hs
+++ b/app/XHR.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
+
+#ifdef wasi_HOST_OS
 
 module XHR (start) where
 
@@ -148,3 +151,7 @@ getGitHubAPIInfo = do
 -- via ghcjs-dom, servant-jsaddle or servant-client-js.
 foreign import javascript safe "const r = await fetch($1); return r.text();"
   js_fetch :: JSString -> IO JSString
+
+#else
+module XHR () where
+#endif

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 packages: . hs2048
 
-index-state: 2025-04-03T07:26:54Z
+index-state: 2025-06-09T12:19:05Z
 
 allow-newer:
   all:base
@@ -18,3 +18,8 @@ if arch(wasm32)
 
 package aeson
   flags: -ordered-keymap
+
+source-repository-package
+  type: git
+  location: https://github.com/dmjio/miso
+  tag: da664f2c33344f545d4fd1c9b2f3c6cbf91c9068

--- a/ghc-wasm-miso-examples.cabal
+++ b/ghc-wasm-miso-examples.cabal
@@ -11,7 +11,6 @@ executable ghc-wasm-miso-examples
       , ghc-experimental
       , hs2048
       , jsaddle
-      , jsaddle-wasm
       , miso >= 1.8.7.0
       , mtl
       , random
@@ -26,4 +25,5 @@ executable ghc-wasm-miso-examples
       Snake
       TodoMVC
       XHR
-    ghc-options: -no-hs-main -optl-mexec-model=reactor "-optl-Wl,--export=hs_start"
+    if arch(wasm32)
+      ghc-options: -no-hs-main -optl-mexec-model=reactor "-optl-Wl,--export=hs_start"

--- a/hs2048/src/InputModel.hs
+++ b/hs2048/src/InputModel.hs
@@ -21,7 +21,6 @@ data Action
   | Sync
   | TouchStart TouchEvent
   | TouchEnd TouchEvent
-  | NoOp
 
 toDirection :: Arrows -> Direction
 toDirection arr@Arrows {..} =

--- a/hs2048/src/Logic.hs
+++ b/hs2048/src/Logic.hs
@@ -148,7 +148,7 @@ step state@GameState {..} =
      | direction /= None -> stepSlide state
      | otherwise -> state
 
-updateGameState :: Action -> GameState -> Effect Action GameState
+updateGameState :: Action -> GameState -> Effect GameState Action
 updateGameState Sync state@GameState {..} =
   noEff state {drawScoreAdd = scoreAdd}
 updateGameState NewGame state = newGame state <# pure Sync
@@ -164,8 +164,8 @@ updateGameState (TouchEnd (TouchEvent touch)) state =
   state {prevTouch = Nothing} <# do
     -- putStrLn "Touch did end"
     let (GetArrows x) =
-          swipe (client . fromJust . prevTouch $ state) (client touch)
+          swipe (Touch.client . fromJust . prevTouch $ state) (Touch.client touch)
     -- print x
-    pure $ swipe (client . fromJust . prevTouch $ state) (client touch)
+    pure $ swipe (Touch.client . fromJust . prevTouch $ state) (Touch.client touch)
 updateGameState Init state = state <# pure NewGame
 updateGameState _ state = noEff state

--- a/hs2048/src/Logic.hs
+++ b/hs2048/src/Logic.hs
@@ -158,7 +158,6 @@ updateGameState (GetArrows arr) = do
 updateGameState (TouchStart (TouchEvent touch)) = do
   modify $ \state -> state {prevTouch = Just touch}
     -- putStrLn "Touch did start"
-  issue NoOp
 updateGameState (TouchEnd (TouchEvent touch)) = do
   state <- get
   put state {prevTouch = Nothing}
@@ -168,4 +167,3 @@ updateGameState (TouchEnd (TouchEvent touch)) = do
     -- print x
   issue $ swipe (Touch.client . fromJust . prevTouch $ state) (Touch.client touch)
 updateGameState Init = issue NewGame
-updateGameState _ = pure ()

--- a/hs2048/src/Logic.hs
+++ b/hs2048/src/Logic.hs
@@ -150,9 +150,9 @@ step state@GameState {..} =
 
 updateGameState :: Action -> GameState -> Effect GameState Action
 updateGameState Sync state@GameState {..} =
-  noEff state {drawScoreAdd = scoreAdd}
+  put state {drawScoreAdd = scoreAdd}
 updateGameState NewGame state = newGame state <# pure Sync
-updateGameState Continue state = noEff state {gameProgress = Continuing}
+updateGameState Continue state = put state {gameProgress = Continuing}
 updateGameState (GetArrows arr) state = step nState <# pure Sync
   where
     nState = state {direction = toDirection arr}
@@ -168,4 +168,4 @@ updateGameState (TouchEnd (TouchEvent touch)) state =
     -- print x
     pure $ swipe (Touch.client . fromJust . prevTouch $ state) (Touch.client touch)
 updateGameState Init state = state <# pure NewGame
-updateGameState _ state = noEff state
+updateGameState _ state = put state

--- a/hs2048/src/Rendering.hs
+++ b/hs2048/src/Rendering.hs
@@ -10,6 +10,7 @@ import InputModel
 import Miso
 import Miso.String (MisoString, ms)
 import qualified Miso.String as S
+import qualified Miso.Style as CSS
 import Touch
 
 black :: MisoString
@@ -211,7 +212,7 @@ display model =
   where
     preview =
       div_
-        [ style_ . M.fromList $
+        [ CSS.style_
           [("left", "100px"), ("width", "100px"), ("position", "absolute")]
         ]
         [text . S.pack . show $ model]

--- a/hs2048/src/Touch.hs
+++ b/hs2048/src/Touch.hs
@@ -42,13 +42,13 @@ touchDecoder = Decoder {..}
     decoder = parseJSON
 
 onTouchMove :: (TouchEvent -> action) -> Attribute action
-onTouchMove = on "touchmove" touchDecoder
+onTouchMove f = on "touchmove" touchDecoder $ const . f
 
 onTouchStart :: (TouchEvent -> action) -> Attribute action
-onTouchStart = on "touchstart" touchDecoder
+onTouchStart f = on "touchstart" touchDecoder $ const . f
 
 onTouchEnd :: (TouchEvent -> action) -> Attribute action
-onTouchEnd = on "touchend" touchDecoder
+onTouchEnd f = on "touchend" touchDecoder $ const . f
 
 touchEvents :: M.Map MisoString Bool
 touchEvents =

--- a/hs2048/src/TwoZeroFourEight.hs
+++ b/hs2048/src/TwoZeroFourEight.hs
@@ -13,6 +13,7 @@ import System.Random
 
 import GameModel
 import InputModel
+import Language.Javascript.JSaddle (JSM)
 import Logic
 import Rendering
 import Touch
@@ -22,13 +23,14 @@ start :: JSM ()
 start = do
   stdGen <- getStdGen
   let (seed, _) = random stdGen
-  startApp App {model = defaultGame {randomSeed = seed}, ..}
+  startComponent Component {model = defaultGame {randomSeed = seed}, ..}
   where
-    initialAction = Init -- initial action to be executed on application load
+    initialAction = Just Init -- initial action to be executed on application load
     model = defaultGame -- initial model
-    update = updateGameState -- update function
+    update a = get >>= updateGameState a -- update function
     view = display -- view function
     events = union touchEvents defaultEvents -- default delegated events
     mountPoint = Nothing -- defaults to body
     subs = [arrowsSub GetArrows] -- empty subscription list
     logLevel = Off
+    styles = []

--- a/hs2048/src/TwoZeroFourEight.hs
+++ b/hs2048/src/TwoZeroFourEight.hs
@@ -27,7 +27,7 @@ start = do
   where
     initialAction = Just Init -- initial action to be executed on application load
     model = defaultGame -- initial model
-    update a = get >>= updateGameState a -- update function
+    update = updateGameState -- update function
     view = display -- view function
     events = union touchEvents defaultEvents -- default delegated events
     mountPoint = Nothing -- defaults to body


### PR DESCRIPTION
A successor to  #23.

This is some stuff I started working on after the Wasm talk at Zurihac. Someone (whose name I didn't catch) was complaining that they wanted an example with `jsaddle-warp` support. I imagined that using the latest development version of Miso and taking advantage of https://github.com/dmjio/miso/pull/770 and others would make support now fairly trivial, but that's unfortunately not really the case.

There's still some stuff missing, notably CSS (could use the new `Miso.Style`?) and "XHR" (`servant-client-js`?). But I'm stashing this here for now since I don't see myself getting back to it especially soon.